### PR TITLE
Add a crop select button, similar to the county select

### DIFF
--- a/app/angular/layout/modalSelect.html
+++ b/app/angular/layout/modalSelect.html
@@ -4,23 +4,18 @@
     <div class="search">
       <span class="fa fa-search fa-2x"></span>
       <input ng-model="searchRegion" type="text" name="select" value="" placeholder="Explore Oregon">
-      <h2>Selected region: <b>{{selected.county.name}}</b></h2>
-      <button class="btn btn-primary" type="button" ng-click="ok((county))">OK</button>
-      <button class="btn btn-warning" type="button" ng-click="cancel()">Cancel</button>
     </div>
   </div>
   <div class="container-fluid">
     <div class="modal-body">
-      <ul>
-        <li class="region-title"> <i class="fa fa-map-marker fa-2x fa-rotate-225"></i> Test Region
-          <ul>
-            <li ng-repeat="county in counties | filter:searchRegion">
-              <a href="#" ng-click="$event.preventDefault(); selected.county = county"> {{county.name}}</a>
-            </li>
-          </ul>
-        </li>
-      </ul>
-
+      <div class="region-title">
+        <i class="fa fa-map-marker fa-2x fa-rotate-225"></i> Oregon Counties
+        <ul>
+          <li ng-repeat="item in dataSet | filter:searchRegion">
+            <a href="#" ng-click="$event.preventDefault(); select(item)"> {{item.name}}</a>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </section>

--- a/app/angular/layout/navbar.html
+++ b/app/angular/layout/navbar.html
@@ -3,8 +3,9 @@
     <span class="orange">Crop</span> <span class="green">Compass</span>
   </h1>
   <div ng-controller="modalSelectCtrl">
-    <button type="button" class="btn btn-link" ng-click="open('lg')"><i class="fa fa-map-marker"></i> Select County</button>
-    <div ng-show="selected">Selected region: {{ selected.name }}</div>
+    <button type="button" class="btn btn-link" ng-click="open('lg', 'crops')">Crop: {{ selected.commodity.name }}</button>
+    <button type="button" class="btn btn-link" ng-click="open('lg', 'region')">
+      <i class="fa fa-map-marker"></i> {{ friendlyCounty() }}</button>
   </div>
 
 <!-- <nav class="navbar navbar-default navbar-fixed-top">

--- a/app/angular/services/farmDataService.js
+++ b/app/angular/services/farmDataService.js
@@ -17,6 +17,12 @@ angular.module('cropApp').factory('farmData', function($http, $log) {
 
 	return {
 
+		getRegions: function() {
+			return checkCache('http://api.cropcompass.org/charts/list_of_regions');
+		},
+		getCommodities: function() {
+			return checkCache('http://api.cropcompass.org/charts/list_of_commodities');
+		},
 		getAcresHarvested: function(countyName, year) {
 			var y = year || 2012;
 			var acresUrl = 'http://api.cropcompass.org/data/oain_harvest_acres?year=' + y + '&region=' + countyName;

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -347,7 +347,8 @@ footer a:focus {
     list-style-type: none;
     padding-top: 10px; }
   .modal-body .region-title {
-    font-size: 30px; }
+    font-size: 30px;
+    margin-left: 20px; }
   .modal-body li {
     font-size: 20px; }
     .modal-body li a {

--- a/app/assets/scss/_modal.scss
+++ b/app/assets/scss/_modal.scss
@@ -36,6 +36,7 @@
   }
   .region-title {
     font-size: 30px;
+    margin-left: 20px;
   }
   li {
     font-size: 20px;


### PR DESCRIPTION
It broadcasts the same event that selecting the county did, and controllers
can listen and check the commodity field now. A user no longer needs to
click ok to apply the selection (initial user tests lead us to believe it
was confusing anyway), so the OK and Cancel buttons were removed.
